### PR TITLE
Bugfix for EINVAL error on ICMPv6

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -336,7 +336,7 @@ impl Pinger {
         let token = random();
         self.inner.state.insert(token, sender);
 
-        let dest = SocketAddr::new(hostname.into(), 1);
+        let dest = SocketAddr::new(hostname.into(), 0);
 
         let (mb_socket, packet) = {
             if dest.is_ipv4() {


### PR DESCRIPTION
Some Linux versions don't accept a port number != 0 in send_to() for ICMPv6 sockets. Setting the port to 0 solves the problem.

Fixes #1