### PR TITLE
Use socket2 instead of lazy_socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-target/
-**/*.rs.bk
 Cargo.lock
+**/*.rs.bk
+.*.sw[po]
+tags
+target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-ping"
-version = "0.1.0"
+version = "0.1.1-alpha"
 license = "MIT/Apache-2.0"
 authors = ["Fedor Gogolev <knsd@knsd.net>"]
 documentation = "https://docs.rs/tokio-ping"
@@ -12,9 +12,9 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 error-chain = "0.11"
 futures = "0.1"
-lazy-socket = "0.2.1"
 libc = "0.2"
 mio = "0.6"
-rand = "0.3"
+rand = "0.4"
+socket2 = "0.3"
 time = "0.1"
 tokio-core = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! tokio-ping is an asynchronous ICMP pinging library.
 //!
-//! The repository is located at https://github.com/knsd/tokio-ping/.
+//! The repository is located at <https://github.com/knsd/tokio-ping/>.
 //!
 //! # Usage example
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,10 @@
 
 #[macro_use] extern crate error_chain;
 extern crate futures;
-extern crate lazy_socket;
 extern crate libc;
 extern crate mio;
 extern crate rand;
+extern crate socket2;
 extern crate time;
 #[macro_use] extern crate tokio_core;
 

--- a/src/packet/icmpv4.rs
+++ b/src/packet/icmpv4.rs
@@ -45,7 +45,7 @@ impl<Data: IcmpV4HeaderData> IcmpV4Header<Data> {
         if data.len() == ICMPV4_HEADER_SIZE {
             let kind = data[0];
             let code = data[1];
-            let checksum = ((data[2] as u16) << 8) + data[3] as u16;
+            let checksum = (u16::from(data[2]) << 8) + u16::from(data[3]);
             let data = Data::decode(&data[4..])?;
             Ok(Self {
                 kind: kind,
@@ -84,8 +84,8 @@ impl IcmpV4HeaderData for IdentSeqData {
 
     fn decode(data: &[u8]) -> errors::Result<Self> {
         if data.len() == ICMPV4_HEADER_DATA_SIZE {
-            let ident = ((data[0] as u16) << 8) + data[1] as u16;
-            let seq_cnt = ((data[2] as u16) << 8) + data[3] as u16;
+            let ident = (u16::from(data[0]) << 8) + u16::from(data[1]);
+            let seq_cnt = (u16::from(data[2]) << 8) + u16::from(data[3]);
 
             Ok(Self {
                 ident: ident,
@@ -128,15 +128,15 @@ impl<'a, Data: IcmpV4HeaderData> RawIcmpV4Message<'a, Data> {
     fn encode(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(ICMPV4_HEADER_SIZE + self.payload.len());
         buf.extend_from_slice(&self.header.encode());
-        buf.extend_from_slice(&self.payload);
+        buf.extend_from_slice(self.payload);
 
         let mut sum = 0u32;
         for word in buf.chunks(2) {
-            let mut part = (word[0] as u16) << 8;
+            let mut part = u16::from(word[0]) << 8;
             if word.len() > 1 {
-                part += word[1] as u16;
+                part += u16::from(word[1]);
             }
-            sum = sum.wrapping_add(part as u32);
+            sum = sum.wrapping_add(u32::from(part));
         }
 
         while (sum >> 16) > 0 {

--- a/src/packet/icmpv6.rs
+++ b/src/packet/icmpv6.rs
@@ -45,7 +45,7 @@ impl<Data: IcmpV6HeaderData> IcmpV6Header<Data> {
         if data.len() == ICMPV6_HEADER_SIZE {
             let kind = data[0];
             let code = data[1];
-            let checksum = ((data[2] as u16) << 8) + data[3] as u16;
+            let checksum = (u16::from(data[2]) << 8) + u16::from(data[3]);
             let data = Data::decode(&data[4..])?;
             Ok(Self {
                 kind: kind,
@@ -84,8 +84,8 @@ impl IcmpV6HeaderData for IdentSeqData {
 
     fn decode(data: &[u8]) -> errors::Result<Self> {
         if data.len() == ICMPV6_HEADER_DATA_SIZE {
-            let ident = ((data[0] as u16) << 8) + data[1] as u16;
-            let seq_cnt = ((data[2] as u16) << 8) + data[3] as u16;
+            let ident = (u16::from(data[0]) << 8) + u16::from(data[1]);
+            let seq_cnt = (u16::from(data[2]) << 8) + u16::from(data[3]);
 
             Ok(Self {
                 ident: ident,
@@ -128,15 +128,15 @@ impl<'a, Data: IcmpV6HeaderData> RawIcmpV6Message<'a, Data> {
     fn encode(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(ICMPV6_HEADER_SIZE + self.payload.len());
         buf.extend_from_slice(&self.header.encode());
-        buf.extend_from_slice(&self.payload);
+        buf.extend_from_slice(self.payload);
 
         let mut sum = 0u32;
         for word in buf.chunks(2) {
-            let mut part = (word[0] as u16) << 8;
+            let mut part = u16::from(word[0]) << 8;
             if word.len() > 1 {
-                part += word[1] as u16;
+                part += u16::from(word[1]);
             }
-            sum = sum.wrapping_add(part as u32);
+            sum = sum.wrapping_add(u32::from(part));
         }
 
         while (sum >> 16) > 0 {

--- a/src/packet/ipv4.rs
+++ b/src/packet/ipv4.rs
@@ -33,28 +33,28 @@ pub struct IpV4Packet<'a> {
 impl<'a> IpV4Packet<'a> {
     pub fn decode(data: &'a [u8]) -> errors::Result<Self> {
         if data.len() < MINIMUM_PACKET_SIZE {
-            return Err(errors::ErrorKind::TooSmallHeader.into())
+            return Err(errors::ErrorKind::TooSmallHeader.into());
         }
         let byte0 = data[0];
         let version = (byte0 & 0xf0) >> 4;
         let header_size = 4 * ((byte0 & 0x0f) as usize);
 
         if version != 4 {
-            return Err(errors::ErrorKind::InvalidVersion.into())
+            return Err(errors::ErrorKind::InvalidVersion.into());
         }
 
         if data.len() < header_size {
-            return Err(errors::ErrorKind::InvalidHeaderSize.into())
+            return Err(errors::ErrorKind::InvalidHeaderSize.into());
         }
 
         let protocol = match IpV4Protocol::decode(data[9]) {
             Some(protocol) => protocol,
-            None => return Err(errors::ErrorKind::UnknownProtocol.into())
+            None => return Err(errors::ErrorKind::UnknownProtocol.into()),
         };
 
         Ok(Self {
             protocol: protocol,
-            data: &data[header_size..]
+            data: &data[header_size..],
         })
     }
 }

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -2,7 +2,7 @@ mod icmpv4;
 mod icmpv6;
 mod ipv4;
 
-pub use self::icmpv4::{IcmpV4Message};
-pub use self::icmpv6::{IcmpV6Message};
+pub use self::icmpv4::IcmpV4Message;
+pub use self::icmpv6::IcmpV6Message;
 
-pub use self::ipv4::{IpV4Protocol, IpV4Packet};
+pub use self::ipv4::{IpV4Packet, IpV4Protocol};

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -7,10 +7,10 @@ use std::rc::{Rc, Weak};
 use std::time::Duration;
 
 use futures::future;
-use futures::sync::oneshot;
 use futures::{Future, Stream, Poll, Async};
-use lazy_socket::raw::{Family, Protocol, Type};
+use futures::sync::oneshot;
 use rand::random;
+use socket2::{Domain, Protocol, Type};
 use time::precise_time_s;
 use tokio_core::reactor::{Handle, Timeout};
 
@@ -246,8 +246,8 @@ enum Sockets {
 
 impl Sockets {
     fn new(handle: &Handle) -> io::Result<Self> {
-        let mb_v4socket = Socket::new(Family::IPv4, Type::RAW, Protocol::ICMPv4, handle);
-        let mb_v6socket = Socket::new(Family::IPv6, Type::RAW, Protocol::ICMPv6, handle);
+        let mb_v4socket = Socket::new(Domain::ipv4(), Type::raw(), Protocol::icmpv4(), handle);
+        let mb_v6socket = Socket::new(Domain::ipv6(), Type::raw(), Protocol::icmpv6(), handle);
         match (mb_v4socket, mb_v6socket) {
             (Ok(v4_socket), Ok(v6_socket)) => {
                 Ok(Sockets::Both {

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -336,7 +336,7 @@ impl Pinger {
         let token = random();
         self.inner.state.insert(token, sender);
 
-        let dest = SocketAddr::new(hostname.into(), 1);
+        let dest = SocketAddr::new(hostname.into(), 0);
 
         let (mb_socket, packet) = {
             if dest.is_ipv4() {

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -7,7 +7,7 @@ use std::rc::{Rc, Weak};
 use std::time::Duration;
 
 use futures::future;
-use futures::{Future, Stream, Poll, Async};
+use futures::{Async, Future, Poll, Stream};
 use futures::sync::oneshot;
 use rand::random;
 use socket2::{Domain, Protocol, Type};
@@ -20,7 +20,6 @@ use socket::Socket;
 
 const DEFAULT_TIMEOUT: u64 = 2;
 type Token = [u8; 32];
-
 
 #[derive(Clone)]
 struct PingState {
@@ -47,18 +46,22 @@ impl PingState {
 #[must_use = "futures do nothing unless polled"]
 pub struct PingFuture {
     start_time: f64,
-    inner: Box<Future<Item=Option<f64>, Error=Error>>,
+    inner: Box<Future<Item = Option<f64>, Error = Error>>,
     pinger: Pinger,
     token: Token,
 }
 
 impl PingFuture {
-    fn new(future: Box<Future<Item=Option<f64>, Error=Error>>, pinger: Pinger, token: Token) -> Self {
+    fn new(
+        future: Box<Future<Item = Option<f64>, Error = Error>>,
+        pinger: Pinger,
+        token: Token,
+    ) -> Self {
         PingFuture {
             start_time: precise_time_s(),
             inner: future,
             pinger: pinger,
-            token: token
+            token: token,
         }
     }
 }
@@ -69,10 +72,12 @@ impl Future for PingFuture {
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         match self.inner.poll() {
-            Ok(Async::Ready(Some(stop_time))) => Ok(Async::Ready(Some(stop_time - self.start_time))),
+            Ok(Async::Ready(Some(stop_time))) => {
+                Ok(Async::Ready(Some(stop_time - self.start_time)))
+            }
             Ok(Async::Ready(None)) => Ok(Async::Ready(None)),
             Ok(Async::NotReady) => Ok(Async::NotReady),
-            Err(err) => Err(err)
+            Err(err) => Err(err),
         }
     }
 }
@@ -173,7 +178,7 @@ impl PingChainStream {
         let future = chain.send();
         Self {
             chain: chain,
-            future: future
+            future: future,
         }
     }
 }
@@ -187,9 +192,9 @@ impl Stream for PingChainStream {
             Ok(Async::Ready(item)) => {
                 self.future = self.chain.send();
                 Ok(Async::Ready(Some(item)))
-            },
+            }
             Ok(Async::NotReady) => Ok(Async::NotReady),
-            Err(err) => Err(err)
+            Err(err) => Err(err),
         }
     }
 }
@@ -200,20 +205,18 @@ struct Finalize {
 
 impl Finalize {
     fn new() -> Self {
-        Self {
-            inner: Rc::new(())
-        }
+        Self { inner: Rc::new(()) }
     }
 
     fn handle(&self) -> FinalizeHandle {
         FinalizeHandle {
-            inner: Rc::downgrade(&self.inner)
+            inner: Rc::downgrade(&self.inner),
         }
     }
 }
 
 struct FinalizeHandle {
-    inner: Weak<()>
+    inner: Weak<()>,
 }
 
 impl FinalizeHandle {
@@ -225,7 +228,7 @@ impl FinalizeHandle {
 /// ICMP packets sender and receiver.
 #[derive(Clone)]
 pub struct Pinger {
-    inner: Rc<PingInner>
+    inner: Rc<PingInner>,
 }
 
 struct PingInner {
@@ -238,10 +241,7 @@ struct PingInner {
 enum Sockets {
     V4(Socket),
     V6(Socket),
-    Both {
-        v4: Socket,
-        v6: Socket,
-    }
+    Both { v4: Socket, v6: Socket },
 }
 
 impl Sockets {
@@ -249,12 +249,10 @@ impl Sockets {
         let mb_v4socket = Socket::new(Domain::ipv4(), Type::raw(), Protocol::icmpv4(), handle);
         let mb_v6socket = Socket::new(Domain::ipv6(), Type::raw(), Protocol::icmpv6(), handle);
         match (mb_v4socket, mb_v6socket) {
-            (Ok(v4_socket), Ok(v6_socket)) => {
-                Ok(Sockets::Both {
-                    v4: v4_socket,
-                    v6: v6_socket,
-                })
-            },
+            (Ok(v4_socket), Ok(v6_socket)) => Ok(Sockets::Both {
+                v4: v4_socket,
+                v6: v6_socket,
+            }),
             (Ok(v4_socket), Err(_)) => Ok(Sockets::V4(v4_socket)),
             (Err(_), Ok(v6_socket)) => Ok(Sockets::V6(v6_socket)),
             (Err(err), Err(_)) => Err(err),
@@ -262,24 +260,23 @@ impl Sockets {
     }
 
     fn v4(&self) -> Option<&Socket> {
-        match self {
-            &Sockets::V4(ref socket) => Some(socket),
-            &Sockets::Both { ref v4, .. } => Some(v4),
-            &Sockets::V6(_) => None
+        match *self {
+            Sockets::V4(ref socket) => Some(socket),
+            Sockets::Both { ref v4, .. } => Some(v4),
+            Sockets::V6(_) => None,
         }
     }
 
     fn v6(&self) -> Option<&Socket> {
-        match self {
-            &Sockets::V4(_) => None,
-            &Sockets::Both { ref v6, .. } => Some(v6),
-            &Sockets::V6(ref socket) => Some(socket)
+        match *self {
+            Sockets::V4(_) => None,
+            Sockets::Both { ref v6, .. } => Some(v6),
+            Sockets::V6(ref socket) => Some(socket),
         }
     }
 }
 
 impl Pinger {
-
     /// Create new `Pinger` instance, will fail if unable to create both IPv4 and IPv6 sockets.
     pub fn new(handle: &Handle) -> io::Result<Self> {
         let sockets = Sockets::new(handle)?;
@@ -288,16 +285,14 @@ impl Pinger {
         let finalize = Finalize::new();
 
         if let Some(v4_socket) = sockets.v4() {
-            let receiver = Receiver::<IcmpV4Message>::new(v4_socket.clone(),
-                                                          state.clone(),
-                                                          finalize.handle());
+            let receiver =
+                Receiver::<IcmpV4Message>::new(v4_socket.clone(), state.clone(), finalize.handle());
             handle.spawn(receiver);
         }
 
         if let Some(v6_socket) = sockets.v6() {
-            let receiver = Receiver::<IcmpV6Message>::new(v6_socket.clone(),
-                                                          state.clone(),
-                                                          finalize.handle());
+            let receiver =
+                Receiver::<IcmpV6Message>::new(v6_socket.clone(), state.clone(), finalize.handle());
             handle.spawn(receiver);
         }
 
@@ -309,7 +304,7 @@ impl Pinger {
         };
 
         Ok(Self {
-            inner: Rc::new(inner)
+            inner: Rc::new(inner),
         })
     }
 
@@ -319,46 +314,62 @@ impl Pinger {
     }
 
     /// Send ICMP request and wait for response.
-    pub fn ping(&self, hostname: IpAddr, ident: u16, seq_cnt: u16, timeout: Duration) -> PingFuture {
+    pub fn ping(
+        &self,
+        hostname: IpAddr,
+        ident: u16,
+        seq_cnt: u16,
+        timeout: Duration,
+    ) -> PingFuture {
         let (sender, receiver) = oneshot::channel();
 
         let timeout_future = future::result(Timeout::new(timeout, &self.inner.handle))
-            .flatten().map_err(From::from).map(|()| None);
+            .flatten()
+            .map_err(From::from)
+            .map(|()| None);
 
-        let send_future = receiver.and_then(|time| {
-            Ok(Some(time))
-        }).map_err(|_| ErrorKind::PingInternalError.into());
+        let send_future = receiver
+            .and_then(|time| Ok(Some(time)))
+            .map_err(|_| ErrorKind::PingInternalError.into());
 
-        let future = timeout_future.select(send_future)
+        let future = timeout_future
+            .select(send_future)
             .map(|(item, _next)| item)
             .map_err(|(item, _next)| item);
 
         let token = random();
         self.inner.state.insert(token, sender);
 
-        let dest = SocketAddr::new(hostname.into(), 0);
+        let dest = SocketAddr::new(hostname, 0);
 
         let (mb_socket, packet) = {
             if dest.is_ipv4() {
-                (self.inner.sockets.v4().cloned(), IcmpV4Message::echo_request(ident, seq_cnt, &token).encode())
-
+                (
+                    self.inner.sockets.v4().cloned(),
+                    IcmpV4Message::echo_request(ident, seq_cnt, &token).encode(),
+                )
             } else {
-                (self.inner.sockets.v6().cloned(), IcmpV6Message::echo_request(ident, seq_cnt, &token).encode())
+                (
+                    self.inner.sockets.v6().cloned(),
+                    IcmpV6Message::echo_request(ident, seq_cnt, &token).encode(),
+                )
             }
         };
 
         let socket = match mb_socket {
             Some(socket) => socket,
             None => {
-                return PingFuture::new(Box::new(
-                    future::err(ErrorKind::InvalidProtocol.into())
-                ), self.clone(), token)
+                return PingFuture::new(
+                    Box::new(future::err(ErrorKind::InvalidProtocol.into())),
+                    self.clone(),
+                    token,
+                )
             }
         };
 
-        self.inner.handle.spawn_fn(move || {
-            socket.send_to(packet, &dest).then(|_| Ok(()))
-        });
+        self.inner
+            .handle
+            .spawn_fn(move || socket.send_to(packet, &dest).then(|_| Ok(())));
 
         PingFuture::new(Box::new(future), self.clone(), token)
     }
@@ -373,18 +384,18 @@ struct Receiver<Message> {
 }
 
 trait ParseReply {
-    fn reply_payload<'a>(data: &'a [u8]) -> Option<&'a [u8]>;
+    fn reply_payload(data: &[u8]) -> Option<&[u8]>;
 }
 
 impl<'b> ParseReply for IcmpV4Message<'b> {
-    fn reply_payload<'a>(data: &'a [u8]) -> Option<&'a [u8]> {
+    fn reply_payload(data: &[u8]) -> Option<&[u8]> {
         if let Ok(ipv4_packet) = IpV4Packet::decode(data) {
             if ipv4_packet.protocol != IpV4Protocol::Icmp {
-                return None
+                return None;
             }
 
             if let Ok(IcmpV4Message::EchoReply(reply)) = IcmpV4Message::decode(ipv4_packet.data) {
-                return Some(reply.payload)
+                return Some(reply.payload);
             }
         }
         None
@@ -392,9 +403,9 @@ impl<'b> ParseReply for IcmpV4Message<'b> {
 }
 
 impl<'b> ParseReply for IcmpV6Message<'b> {
-    fn reply_payload<'a>(data: &'a [u8]) -> Option<&'a [u8]> {
+    fn reply_payload(data: &[u8]) -> Option<&[u8]> {
         if let Ok(IcmpV6Message::EchoReply(reply)) = IcmpV6Message::decode(data) {
-            return Some(reply.payload)
+            return Some(reply.payload);
         }
         None
     }
@@ -402,16 +413,13 @@ impl<'b> ParseReply for IcmpV6Message<'b> {
 
 impl<Proto> Receiver<Proto> {
     fn new(socket: Socket, state: PingState, finalize: FinalizeHandle) -> Self {
-
-        let receiver = Self {
+        Self {
             socket: socket,
             finalize: finalize,
             state: state,
             buffer: [0; 2048],
             _phantom: ::std::marker::PhantomData,
-        };
-
-        receiver
+        }
     }
 }
 
@@ -421,7 +429,7 @@ impl<Message: ParseReply> Future for Receiver<Message> {
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         if !self.finalize.is_alive() {
-            return Ok(Async::Ready(()))
+            return Ok(Async::Ready(()));
         }
 
         match self.socket.recv(&mut self.buffer) {
@@ -433,7 +441,7 @@ impl<Message: ParseReply> Future for Receiver<Message> {
                     }
                 }
                 self.poll()
-            },
+            }
             Ok(Async::NotReady) => Ok(Async::NotReady),
             Err(_) => Err(()),
         }

--- a/src/socket/mio.rs
+++ b/src/socket/mio.rs
@@ -1,34 +1,32 @@
 use std::io;
 
-use std::net::SocketAddr;
 use std::os::unix::io::{RawFd, AsRawFd};
 
-use lazy_socket::raw::{Socket as LazySocket};
-use libc::c_int;
 use mio::{Evented, Poll, Token, Ready, PollOpt};
 use mio::unix::EventedFd;
+use socket2::{Domain, Protocol, Type, SockAddr, Socket as Socket2};
 
 
 pub struct Socket {
-    socket: LazySocket,
+    socket: Socket2,
 }
 
 impl Socket {
-    pub fn new(family: c_int, type_: c_int, protocol: c_int) -> io::Result<Self> {
-        let socket = LazySocket::new(family, type_, protocol)?;
-        socket.set_blocking(false)?;
+    pub fn new(domain: Domain, type_: Type, protocol: Protocol) -> io::Result<Self> {
+        let socket = Socket2::new(domain, type_, Some(protocol))?;
+        socket.set_nonblocking(true)?;
 
         Ok(Self {
             socket: socket
         })
     }
 
-    pub fn send_to(&self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
-        self.socket.send_to(buf, target, 0)
+    pub fn send_to(&self, buf: &[u8], target: &SockAddr) -> io::Result<usize> {
+        self.socket.send_to(buf, target)
     }
 
     pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.socket.recv(buf, 0)
+        self.socket.recv(buf)
     }
 }
 

--- a/src/socket/mio.rs
+++ b/src/socket/mio.rs
@@ -1,11 +1,10 @@
 use std::io;
 
-use std::os::unix::io::{RawFd, AsRawFd};
+use std::os::unix::io::{AsRawFd, RawFd};
 
-use mio::{Evented, Poll, Token, Ready, PollOpt};
+use mio::{Evented, Poll, PollOpt, Ready, Token};
 use mio::unix::EventedFd;
-use socket2::{Domain, Protocol, Type, SockAddr, Socket as Socket2};
-
+use socket2::{Domain, Protocol, SockAddr, Socket as Socket2, Type};
 
 pub struct Socket {
     socket: Socket2,
@@ -16,9 +15,7 @@ impl Socket {
         let socket = Socket2::new(domain, type_, Some(protocol))?;
         socket.set_nonblocking(true)?;
 
-        Ok(Self {
-            socket: socket
-        })
+        Ok(Self { socket: socket })
     }
 
     pub fn send_to(&self, buf: &[u8], target: &SockAddr) -> io::Result<usize> {
@@ -37,11 +34,23 @@ impl AsRawFd for Socket {
 }
 
 impl Evented for Socket {
-    fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+    fn register(
+        &self,
+        poll: &Poll,
+        token: Token,
+        interest: Ready,
+        opts: PollOpt,
+    ) -> io::Result<()> {
         EventedFd(&self.as_raw_fd()).register(poll, token, interest, opts)
     }
 
-    fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt) -> io::Result<()> {
+    fn reregister(
+        &self,
+        poll: &Poll,
+        token: Token,
+        interest: Ready,
+        opts: PollOpt,
+    ) -> io::Result<()> {
         EventedFd(&self.as_raw_fd()).reregister(poll, token, interest, opts)
     }
 

--- a/src/socket/tokio.rs
+++ b/src/socket/tokio.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use futures;
 use std::net::SocketAddr;
 use tokio_core::reactor::{Handle, PollEvented};
-use socket2::{Domain, Protocol, Type, SockAddr};
+use socket2::{Domain, Protocol, SockAddr, Type};
 
 use socket::mio;
 
@@ -14,7 +14,12 @@ pub struct Socket {
 }
 
 impl Socket {
-    pub fn new (domain: Domain, type_: Type, protocol: Protocol, handle: &Handle) -> io::Result<Self> {
+    pub fn new(
+        domain: Domain,
+        type_: Type,
+        protocol: Protocol,
+        handle: &Handle,
+    ) -> io::Result<Self> {
         let socket = mio::Socket::new(domain, type_, protocol)?;
         let socket = PollEvented::new(socket, handle)?;
         Ok(Self {
@@ -22,7 +27,10 @@ impl Socket {
         })
     }
 
-    pub fn send_to<T>(&self, buf: T, target: &SocketAddr) -> Send<T> where T: AsRef<[u8]> {
+    pub fn send_to<T>(&self, buf: T, target: &SocketAddr) -> Send<T>
+    where
+        T: AsRef<[u8]>,
+    {
         Send {
             state: SendState::Writing {
                 socket: self.socket.clone(),
@@ -33,12 +41,12 @@ impl Socket {
     }
 
     pub fn recv(&self, buffer: &mut [u8]) -> futures::Poll<usize, io::Error> {
-        Ok(futures::Async::Ready(try_nb!(recv(self.socket.clone(), buffer))))
+        Ok(futures::Async::Ready(try_nb!(recv(&self.socket, buffer))))
     }
 }
 
 pub struct Send<T> {
-    state: SendState<T>
+    state: SendState<T>,
 }
 
 enum SendState<T> {
@@ -50,9 +58,13 @@ enum SendState<T> {
     Empty,
 }
 
-fn send_to(socket: Rc<PollEvented<mio::Socket>>, buf: &[u8], target: &SockAddr) -> io::Result<usize> {
+fn send_to(
+    socket: &Rc<PollEvented<mio::Socket>>,
+    buf: &[u8],
+    target: &SockAddr,
+) -> io::Result<usize> {
     if let futures::Async::NotReady = socket.poll_write() {
-        return Err(io::ErrorKind::WouldBlock.into())
+        return Err(io::ErrorKind::WouldBlock.into());
     }
     match socket.get_ref().send_to(buf, target) {
         Ok(n) => Ok(n),
@@ -65,9 +77,9 @@ fn send_to(socket: Rc<PollEvented<mio::Socket>>, buf: &[u8], target: &SockAddr) 
     }
 }
 
-fn recv(socket: Rc<PollEvented<mio::Socket>>, buf: &mut [u8]) -> io::Result<usize> {
+fn recv(socket: &Rc<PollEvented<mio::Socket>>, buf: &mut [u8]) -> io::Result<usize> {
     if let futures::Async::NotReady = socket.poll_read() {
-        return Err(io::ErrorKind::WouldBlock.into())
+        return Err(io::ErrorKind::WouldBlock.into());
     }
     match socket.get_ref().recv(buf) {
         Ok(n) => Ok(n),
@@ -80,27 +92,33 @@ fn recv(socket: Rc<PollEvented<mio::Socket>>, buf: &mut [u8]) -> io::Result<usiz
     }
 }
 
-
-impl<T> futures::Future for Send<T> where T: AsRef<[u8]> {
+impl<T> futures::Future for Send<T>
+where
+    T: AsRef<[u8]>,
+{
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> futures::Poll<(), io::Error> {
         match self.state {
-            SendState::Writing { ref socket, ref buf, ref addr } => {
-                let n = try_nb!(send_to(socket.clone(), buf.as_ref(), addr));
+            SendState::Writing {
+                ref socket,
+                ref buf,
+                ref addr,
+            } => {
+                let n = try_nb!(send_to(socket, buf.as_ref(), addr));
                 if n != buf.as_ref().len() {
-                    return Err(io::Error::new(io::ErrorKind::Other,
-                                              "failed to send entire packet"))
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        "failed to send entire packet",
+                    ));
                 }
             }
             SendState::Empty => panic!("poll a Send after it's done"),
         }
 
         match ::std::mem::replace(&mut self.state, SendState::Empty) {
-            SendState::Writing { .. } => {
-                Ok(futures::Async::Ready(()))
-            }
+            SendState::Writing { .. } => Ok(futures::Async::Ready(())),
             SendState::Empty => unreachable!(),
         }
     }


### PR DESCRIPTION
lazy_socket is discontinued according to <https://github.com/DoumanAsh/lazy-socket.rs>. Use equivalent functions from socket2 instead.
    
Note that this changes makes tokio-ping compile with MUSL (failed beforehand due to a data type mismatch).

Also applied some rustfmt and clippy goodness. This PR incorporates formatting and style improvements brought forward by rustfmt-nightly and clippy. Feel free to reject any parts of it if you don't like it.

