### PR TITLE
Clean-up Clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ libc = "0.2"
 mio = "0.6"
 rand = "0.4"
 socket2 = "0.3"
-tokio-executor="0.1.2"
-tokio-reactor = "0.1.1"
-tokio-timer = "0.2.3"
+tokio-executor="0.1.10"
+tokio-reactor = "0.1.12"
+tokio-timer = "0.2.13"
 parking_lot = "0.5.5"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/knsd/tokio-ping"
 description = "Asynchronous ICMP pinging library"
 keywords = ["tokio", "icmp", "ping"]
 categories = ["network-programming", "asynchronous"]
+edition = "2018"
 
 [dependencies]
 failure = "0.1.1"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,7 +8,7 @@ pub struct Error {
 }
 
 impl Fail for Error {
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.inner.cause()
     }
 
@@ -31,7 +31,7 @@ impl From<ErrorKind> for Error {
 
 impl From<Context<ErrorKind>> for Error {
     fn from(inner: Context<ErrorKind>) -> Error {
-        Error { inner: inner }
+        Error { inner }
     }
 }
 
@@ -47,7 +47,7 @@ impl From<::std::io::Error> for Error {
 
 #[derive(Debug, Fail)]
 pub enum ErrorKind {
-    #[fail(display = "invalid procotol")]
+    #[fail(display = "invalid protocol")]
     InvalidProtocol,
     #[fail(display = "internal error")]
     InternalError,

--- a/src/packet/icmp.rs
+++ b/src/packet/icmp.rs
@@ -50,7 +50,7 @@ impl<'a> EchoRequest<'a> {
         buffer[6] = (self.seq_cnt >> 8) as u8;
         buffer[7] = self.seq_cnt as u8;
 
-        if let Err(_) = (&mut buffer[8..]).write(self.payload) {
+        if (&mut buffer[8..]).write(self.payload).is_err() {
             return Err(Error::InvalidSize)
         }
 

--- a/src/packet/ipv4.rs
+++ b/src/packet/ipv4.rs
@@ -54,7 +54,7 @@ impl<'a> IpV4Packet<'a> {
         };
 
         Ok(Self {
-            protocol: protocol,
+            protocol,
             data: &data[header_size..],
         })
     }

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -137,8 +137,8 @@ pub struct PingChain {
 impl PingChain {
     fn new(pinger: Pinger, hostname: IpAddr) -> Self {
         Self {
-            pinger: pinger,
-            hostname: hostname,
+            pinger,
+            hostname,
             ident: None,
             seq_cnt: None,
             timeout: None,
@@ -213,7 +213,7 @@ pub struct PingChainStream {
 impl PingChainStream {
     fn new(chain: PingChain) -> Self {
         Self {
-            chain: chain,
+            chain,
             future: None,
         }
     }
@@ -323,8 +323,8 @@ impl Pinger {
         };
 
         let inner = PingInner {
-            sockets: sockets,
-            state: state,
+            sockets,
+            state,
             _v4_finalize: v4_finalize,
             _v6_finalize: v6_finalize,
         };
@@ -358,8 +358,8 @@ impl Pinger {
         let mut buffer = [0; ECHO_REQUEST_BUFFER_SIZE];
 
         let request = EchoRequest {
-            ident: ident,
-            seq_cnt: seq_cnt,
+            ident,
+            seq_cnt,
             payload: &token,
         };
 
@@ -387,7 +387,7 @@ impl Pinger {
             }
         };
 
-        if let Err(_) = encode_result {
+        if encode_result.is_err() {
             return PingFuture {
                 inner: PingFutureKind::PacketEncodeError
             }
@@ -399,10 +399,10 @@ impl Pinger {
             inner: PingFutureKind::Normal(NormalPingFutureKind {
                 start_time: Instant::now(),
                 state: self.inner.state.clone(),
-                token: token,
+                token,
                 delay: Delay::new(deadline),
                 send: Some(send_future),
-                receiver: receiver,
+                receiver,
             })
         }
     }
@@ -446,8 +446,8 @@ impl ParseReply for IcmpV6 {
 impl<Proto> Receiver<Proto> {
     fn new(socket: Socket, state: PingState) -> Self {
         Self {
-            socket: socket,
-            state: state,
+            socket,
+            state,
             buffer: [0; 2048],
             _phantom: ::std::marker::PhantomData,
         }

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -15,10 +15,10 @@ use tokio_executor::spawn;
 use tokio_reactor::Handle;
 use tokio_timer::Delay;
 
-use errors::{Error, ErrorKind};
-use packet::{IpV4Packet, IpV4Protocol};
-use packet::{ICMP_HEADER_SIZE, IcmpV4, IcmpV6, EchoRequest, EchoReply};
-use socket::{Socket, Send};
+use crate::errors::{Error, ErrorKind};
+use crate::packet::{IpV4Packet, IpV4Protocol};
+use crate::packet::{ICMP_HEADER_SIZE, IcmpV4, IcmpV6, EchoRequest, EchoReply};
+use crate::socket::{Socket, Send};
 
 const DEFAULT_TIMEOUT: u64 = 2;
 const TOKEN_SIZE: usize = 24;

--- a/src/socket/mio.rs
+++ b/src/socket/mio.rs
@@ -15,7 +15,7 @@ impl Socket {
         let socket = Socket2::new(domain, type_, Some(protocol))?;
         socket.set_nonblocking(true)?;
 
-        Ok(Self { socket: socket })
+        Ok(Self { socket })
     }
 
     pub fn send_to(&self, buf: &[u8], target: &SockAddr) -> io::Result<usize> {

--- a/src/socket/tokio.rs
+++ b/src/socket/tokio.rs
@@ -36,7 +36,7 @@ impl Socket {
             state: SendState::Writing {
                 socket: self.socket.clone(),
                 addr: target.clone().into(),
-                buf: buf,
+                buf,
             },
         }
     }

--- a/src/socket/tokio.rs
+++ b/src/socket/tokio.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 
 use futures;
 use std::net::SocketAddr;
-use mio::Ready;
+use crate::mio::Ready;
 use tokio_reactor::{Handle, PollEvented};
 use socket2::{Domain, Protocol, SockAddr, Type};
 
-use socket::mio;
+use crate::socket::mio;
 
 #[derive(Clone)]
 pub struct Socket {


### PR DESCRIPTION
Fix all clippy warnings and a spelling mistake, and update to Edition 2018